### PR TITLE
Bump pytest maximum version to <9

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 pytablewriter>=1.2.0,<2
-pytest>=3.3.2,<8,!=6.0.0
+pytest>=3.3.2,<9,!=6.0.0
 tcolorpy>=0.0.5,<1
 typepy>=1.1.1,<2


### PR DESCRIPTION
Closes #5

Just increased the max to `<9` let me know if you want to ditch the max all together 👍🏻 