### PR TITLE
readme: typo: emmpty -> empty

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Increase verbosity level (``--md-report-verbose`` option):
 
     Output example (verbose)
 
-Not rendering results of zero value (``--md-report-zeros emmpty`` option):
+Not rendering results of zero value (``--md-report-zeros empty`` option):
 
 ::
 


### PR DESCRIPTION
so people don't blindly copy-paste this flag and wonder why it doesn't work